### PR TITLE
Replace email with link in maintainers

### DIFF
--- a/pages/components/_id.vue
+++ b/pages/components/_id.vue
@@ -50,8 +50,8 @@
               <h6 class="title">
                 Maintainers
               </h6>
-              <div v-for="maintainer in component.maintainers" :key="maintainer.email" class="maintainer">
-                <b-link :href="`mailto:${maintainer.email}`">
+              <div v-for="maintainer in component.maintainers" :key="maintainer.link" class="maintainer">
+                <b-link :href="`${maintainer.link}`">
                   {{ maintainer.name }}
                 </b-link>
               </div>

--- a/test/fixtures/responses/components.json
+++ b/test/fixtures/responses/components.json
@@ -14,11 +14,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -42,11 +42,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -70,11 +70,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -98,11 +98,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -126,11 +126,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -154,11 +154,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -182,11 +182,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -211,11 +211,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -239,11 +239,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -267,11 +267,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -295,11 +295,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [
@@ -323,11 +323,11 @@
     "maintainers": [
       {
         "name": "nestorsalceda",
-        "email": "nestor.salceda@sysdig.com"
+        "link": "github.com/nestorsalceda"
       },
       {
         "name": "fedebarcelona",
-        "email": "fede.barcelona@sysdig.com"
+        "link": "github.com/tembleking"
       }
     ],
     "rules": [


### PR DESCRIPTION
Maybe a maintainer doesn't want to publish it's e-mail, this PR replaces the e-mail with a generic link from the maintainer structure.