### PR TITLE
Remove author entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "cloud-native-security-hub",
   "version": "1.0.0",
   "description": "Cloud Native Security Hub",
-  "author": "Nacho García",
   "private": true,
   "scripts": {
     "build": "nuxt build",


### PR DESCRIPTION
Removing this from package.json we get no <meta> author information in HTML, which displayed "Nacho García" in link previews when sharing the web URL over Slack or similar.